### PR TITLE
New type of URLs

### DIFF
--- a/src/InstagramScraper/Model/Media.php
+++ b/src/InstagramScraper/Model/Media.php
@@ -91,9 +91,17 @@ class Media
     private static function getImageUrls($imageUrl)
     {
         $imageUrl = self::getCleanImageUrl($imageUrl);
-        $imageUrl = str_replace('s480x480/', "", $imageUrl);
         $parts = explode('/', parse_url($imageUrl)['path']);
-        $standard = 'https://scontent.cdninstagram.com/' . $parts[1] . '/s640x640/' . $parts[2] . '/' . $parts[3];
+        if (sizeof($parts) == 4){
+            $standard = 'https://scontent.cdninstagram.com/' . $parts[1] . '/s640x640/' . $parts[2] . '/' . $parts[3];
+        } else {
+            if (isset($parts[4]) && $parts[4][0] == 'p') {
+                $standard = 'https://scontent.cdninstagram.com/' . $parts[1] . '/p640x640/' . $parts[3] . '/' . $parts[5];
+            } else {
+                $standard = 'https://scontent.cdninstagram.com/' . $parts[1] . '/s640x640/' . $parts[3] . '/' . $parts[5];
+            }
+        }
+
         $urls = [
             'standard' => $standard,
             'low' => str_replace('640x640', '320x320', $standard),


### PR DESCRIPTION
Instagram use other url for portal photos.

`"display_src": "https://scontent-arn2-1.cdninstagram.com/t51.2885-15/sh0.08/e35/p750x750/12940175_568780379950722_428597806_n.jpg?ig_cache_key=MTIzNDgzOTgyMDA4NDEyMjMzNg%3D%3D.2",`

example: [photo](https://www.instagram.com/p/BEjCEYenxLg/?__a=1)