### PR TITLE
Add urlencode to endpoint urls

### DIFF
--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -21,69 +21,69 @@ class Endpoints
 
     public static function getAccountPageLink($username)
     {
-        return str_replace('{username}', $username, Endpoints::ACCOUNT_PAGE);
+        return str_replace('{username}', urlencode($username), Endpoints::ACCOUNT_PAGE);
     }
 
     public static function getAccountJsonLink($username)
     {
-        return str_replace('{username}', $username, Endpoints::ACCOUNT_JSON_INFO);
+        return str_replace('{username}', urlencode($username), Endpoints::ACCOUNT_JSON_INFO);
     }
 
     public static function getAccountJsonInfoLinkByAccountId($id)
     {
-        return str_replace('{userId}', $id, Endpoints::ACCOUNT_JSON_INFO_BY_ID);
+        return str_replace('{userId}', urlencode($id), Endpoints::ACCOUNT_JSON_INFO_BY_ID);
     }
 
     public static function getAccountMediasJsonLink($username, $maxId = '')
     {
-        $url = str_replace('{username}', $username, Endpoints::ACCOUNT_MEDIAS);
-        return str_replace('{max_id}', $maxId, $url);
+        $url = str_replace('{username}', urlencode($username), Endpoints::ACCOUNT_MEDIAS);
+        return str_replace('{max_id}', urlencode($maxId), $url);
     }
 
     public static function getMediaPageLink($code)
     {
-        return str_replace('{code}', $code, Endpoints::MEDIA_LINK);
+        return str_replace('{code}', urlencode($code), Endpoints::MEDIA_LINK);
     }
 
     public static function getMediaJsonLink($code)
     {
-        return str_replace('{code}', $code, Endpoints::MEDIA_JSON_INFO);
+        return str_replace('{code}', urlencode($code), Endpoints::MEDIA_JSON_INFO);
     }
 
     public static function getMediasJsonByLocationIdLink($facebookLocationId, $maxId = '')
     {
-        $url = str_replace('{{facebookLocationId}}', $facebookLocationId, Endpoints::MEDIA_JSON_BY_LOCATION_ID);
-        return str_replace('{{maxId}}', $maxId, $url);
+        $url = str_replace('{{facebookLocationId}}', urlencode($facebookLocationId), Endpoints::MEDIA_JSON_BY_LOCATION_ID);
+        return str_replace('{{maxId}}', urlencode($maxId), $url);
     }
 
     public static function getMediasJsonByTagLink($tag, $maxId = '')
     {
-        $url = str_replace('{tag}', $tag, Endpoints::MEDIA_JSON_BY_TAG);
-        return str_replace('{max_id}', $maxId, $url);
+        $url = str_replace('{tag}', urlencode($tag), Endpoints::MEDIA_JSON_BY_TAG);
+        return str_replace('{max_id}', urlencode($maxId), $url);
     }
 
     public static function getGeneralSearchJsonLink($query)
     {
-        return str_replace('{query}', $query, Endpoints::GENERAL_SEARCH);
+        return str_replace('{query}', urlencode($query), Endpoints::GENERAL_SEARCH);
     }
 
     public static function getLastCommentsByCodeLink($code, $count)
     {
-        $url = str_replace('{{code}}', $code, Endpoints::LAST_COMMENTS_BY_CODE);
-        return str_replace('{{count}}', $count, $url);
+        $url = str_replace('{{code}}', urlencode($code), Endpoints::LAST_COMMENTS_BY_CODE);
+        return str_replace('{{count}}', urlencode($count), $url);
 
     }
 
     public static function getCommentsBeforeCommentIdByCode($code, $count, $commentId)
     {
-        $url = str_replace('{{code}}', $code, Endpoints::COMMENTS_BEFORE_COMMENT_ID_BY_CODE);
-        $url = str_replace('{{count}}', $count, $url);
-        return str_replace('{{commentId}}', $commentId, $url);
+        $url = str_replace('{{code}}', urlencode($code), Endpoints::COMMENTS_BEFORE_COMMENT_ID_BY_CODE);
+        $url = str_replace('{{count}}', urlencode($count), $url);
+        return str_replace('{{commentId}}', urlencode($commentId), $url);
     }
-    
+
     public static function getLastLikesByCodeLink($code)
     {
-        $url = str_replace('{{code}}', $code, Endpoints::LAST_LIKES_BY_CODE);
+        $url = str_replace('{{code}}', urlencode($code), Endpoints::LAST_LIKES_BY_CODE);
         return $url;
 
     }


### PR DESCRIPTION
We got http 400 error when we crawled Japanese hashtag.
This is caused by un-encoded url parameter at src/InstagramScraper/Endpoints.php.

However, whole url parameters should be urlencoded when this library sends request to instagram.
This pull request and diff fixes the problem.

I hope this would help. 
Thank you,
Shota