### PR TITLE
getAccount() fixed to get all missing user data.

### DIFF
--- a/src/InstagramScraper/Endpoints.php
+++ b/src/InstagramScraper/Endpoints.php
@@ -6,7 +6,7 @@ class Endpoints
 {
     const BASE_URL = 'https://www.instagram.com';
     const LOGIN_URL = 'https://www.instagram.com/accounts/login/ajax/';
-    const ACCOUNT_PAGE = 'https://www.instagram.com/{username}/';
+    const ACCOUNT_PAGE = 'https://www.instagram.com/api/v1/users/web_profile_info/?username={username}';
     const MEDIA_LINK = 'https://www.instagram.com/p/{code}';
     const ACCOUNT_MEDIAS = 'https://www.instagram.com/graphql/query/?query_hash=e769aa130647d2354c40ea6a439bfc08&variables={variables}';
     const ACCOUNT_TAGGED_MEDIAS = 'https://www.instagram.com/graphql/query/?query_hash=be13233562af2d229b008d2976b998b5&variables={variables}';

--- a/src/InstagramScraper/Instagram.php
+++ b/src/InstagramScraper/Instagram.php
@@ -415,6 +415,9 @@ class Instagram
 
         }
 
+        //user agent to retrieve account data
+        $this->setUserAgent("Instagram 219.0.0.12.117 Android");
+	
         if ($this->getUserAgent()) {
             $headers['user-agent'] = $this->getUserAgent();
 
@@ -738,11 +741,11 @@ class Instagram
             throw new InstagramAgeRestrictedException('Account with given username is age-restricted.');
         }
 
-        if (!isset($userArray['entry_data']['ProfilePage'][0]['graphql']['user'])) {
+        if (!isset($userArray['entry_data']['ProfilePage'][0]['graphql']['user']) && !isset($userArray['data']['user'])) {
             throw new InstagramException('Response code is ' . $response->code . ': ' . static::httpCodeToString($response->code) . '.' .
                                          'Something went wrong. Please report issue.', $response->code, static::getErrorBody($response->body));
         }
-        return Account::create($userArray['entry_data']['ProfilePage'][0]['graphql']['user']);
+        return Account::create($userArray['entry_data']['ProfilePage'][0]['graphql']['user']?? $userArray['data']['user']);
     }
 
     public function getAccountInfo($username)
@@ -772,7 +775,7 @@ class Instagram
         if (preg_match_all('#\_sharedData \= (.*?)\;\<\/script\>#', $body, $out)) {
             return json_decode($out[1][0], true, 512, JSON_BIGINT_AS_STRING);
         }
-        return null;
+        return json_decode($body, true, 512, JSON_BIGINT_AS_STRING);
     }
 
     private function isAccountAgeRestricted($userArray, $body)
@@ -1430,7 +1433,7 @@ class Instagram
             if (empty($nodes)) {
                 return $medias;
             }
-            $maxId = $arr[$rootKey]['recent']['next_max_id']; // $arr[$rootKey]['hashtag']['edge_hashtag_to_media']['page_info']['end_cursor'];
+            $maxId = $arr[$rootKey]['recent']['next_max_id']?? ''; // $arr[$rootKey]['hashtag']['edge_hashtag_to_media']['page_info']['end_cursor'];
             $hasNextPage = $arr[$rootKey]['recent']['more_available']; // $arr[$rootKey]['hashtag']['edge_hashtag_to_media']['page_info']['has_next_page'];
         }
         return $medias;


### PR DESCRIPTION
Hi I have been using your repo and I noticed that doing getOwner() on a media type object returned the user with very little information than it should have initially.

Investigating several of the open issues I found that the sharedResponse object is no longer being returned when requesting user information.

So, to somehow solve my problem and get all the user account information, I modified the endpoint to get the user account information (ACCOUNT_PAGE) and made some modifications to process the new response.

With these changes you can now get the missing user information from getOwner() using getAccount($username) (and the username may well be obtained from getOwner as it is one of the few fields it does return).

I hope it can help someone else.

PS: the change of $maxId is because sometimes it triggers Undeffined index, if so, it is placed as an empty string and works without problems.